### PR TITLE
Use correct queue names as defaults #70

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ Listeners subsection has the following format:
 
 | Option | Explanation | Example |
 |--------|-------------|---------|
-| `accountMargin` | Queue name for account margin data | `broadcast.PRISMA_BRIDGE.PRISMA_TTSAVEAccountMargin` |
-| `liquiGroupMargin` | Queue name for liqui group margin data | `broadcast.PRISMA_BRIDGE.PRISMA_TTSAVELiquiGroupMargin` |
-| `liquiGroupSplitMargin` | Queue name for liqui group split margin data | `broadcast.PRISMA_BRIDGE.PRISMA_TTSAVELiquiGroupSplitMargin` |
-| `positionReport` | Queue name for position report data | `broadcast.PRISMA_BRIDGE.PRISMA_TTSAVEPositionReport` |
-| `poolMargin` | Queue name for pool margin data | `broadcast.PRISMA_BRIDGE.PRISMA_TTSAVEPoolMargin` |
-| `riskLimitUtilization` | Queue name for risk limit utilization data | `broadcast.PRISMA_BRIDGE.PRISMA_TTSAVERiskLimitUtilization` |
+| `accountMargin` | Queue name for account margin data | `broadcast.DAVE.PRISMA_DAVEAccountMargin` |
+| `liquiGroupMargin` | Queue name for liqui group margin data | `broadcast.DAVE.PRISMA_DAVELiquiGroupMargin` |
+| `liquiGroupSplitMargin` | Queue name for liqui group split margin data | `broadcast.DAVE.PRISMA_DAVELiquiGroupSplitMargin` |
+| `positionReport` | Queue name for position report data | `broadcast.DAVE.PRISMA_DAVEPositionReport` |
+| `poolMargin` | Queue name for pool margin data | `broadcast.DAVE.PRISMA_DAVEPoolMargin` |
+| `riskLimitUtilization` | Queue name for risk limit utilization data | `broadcast.DAVE.PRISMA_DAVERiskLimitUtilization` |
 
 ### StoreManager
 

--- a/etc/marginloader.conf
+++ b/etc/marginloader.conf
@@ -6,12 +6,12 @@ amqp {
   reconnectAttempts = -1
   reconnectTimeout = 10000
   listeners {
-    accountMargin = "broadcast.PRISMA_BRIDGE.PRISMA_TTSAVEAccountMargin"
-    liquiGroupMargin = "broadcast.PRISMA_BRIDGE.PRISMA_TTSAVELiquiGroupMargin"
-    liquiGroupSplitMargin = "broadcast.PRISMA_BRIDGE.PRISMA_TTSAVELiquiGroupSplitMargin"
-    positionReport = "broadcast.PRISMA_BRIDGE.PRISMA_TTSAVEPositionReport"
-    poolMargin = "broadcast.PRISMA_BRIDGE.PRISMA_TTSAVEPoolMargin"
-    riskLimitUtilization = "broadcast.PRISMA_BRIDGE.PRISMA_TTSAVERiskLimitUtilization"
+    accountMargin = "broadcast.DAVE.PRISMA_DAVEAccountMargin"
+    liquiGroupMargin = "broadcast.DAVE.PRISMA_DAVELiquiGroupMargin"
+    liquiGroupSplitMargin = "broadcast.DAVE.PRISMA_DAVELiquiGroupSplitMargin"
+    positionReport = "broadcast.DAVE.PRISMA_DAVEPositionReport"
+    poolMargin = "broadcast.DAVE.PRISMA_DAVEPoolMargin"
+    riskLimitUtilization = "broadcast.DAVE.PRISMA_DAVERiskLimitUtilization"
   }
   circuitBreaker {
     maxFailures = 3

--- a/src/main/java/com/deutscheboerse/risk/dave/config/AmqpConfig.java
+++ b/src/main/java/com/deutscheboerse/risk/dave/config/AmqpConfig.java
@@ -70,12 +70,12 @@ public class AmqpConfig {
     }
 
     public static class ListenersConfig {
-        private static final String DEFAULT_ACCOUNT_MARGIN = "broadcast.PRISMA_BRIDGE.PRISMA_TTSAVEAccountMargin";
-        private static final String DEFAULT_LIQUI_GROUP_MARGIN = "broadcast.PRISMA_BRIDGE.PRISMA_TTSAVELiquiGroupMargin";
-        private static final String DEFAULT_LIQUI_GROUP_SPLIT_MARGIN = "broadcast.PRISMA_BRIDGE.PRISMA_TTSAVELiquiGroupSplitMargin";
-        private static final String DEFAULT_POSITION_REPORT = "broadcast.PRISMA_BRIDGE.PRISMA_TTSAVEPositionReport";
-        private static final String DEFAULT_POOL_MARGIN = "broadcast.PRISMA_BRIDGE.PRISMA_TTSAVEPoolMargin";
-        private static final String DEFAULT_RISK_LIMIT_UTILIZATION = "broadcast.PRISMA_BRIDGE.PRISMA_TTSAVERiskLimitUtilization";
+        private static final String DEFAULT_ACCOUNT_MARGIN = "broadcast.DAVE.PRISMA_DAVEAccountMargin";
+        private static final String DEFAULT_LIQUI_GROUP_MARGIN = "broadcast.DAVE.PRISMA_DAVELiquiGroupMargin";
+        private static final String DEFAULT_LIQUI_GROUP_SPLIT_MARGIN = "broadcast.DAVE.PRISMA_DAVELiquiGroupSplitMargin";
+        private static final String DEFAULT_POSITION_REPORT = "broadcast.DAVE.PRISMA_DAVEPositionReport";
+        private static final String DEFAULT_POOL_MARGIN = "broadcast.DAVE.PRISMA_DAVEPoolMargin";
+        private static final String DEFAULT_RISK_LIMIT_UTILIZATION = "broadcast.DAVE.PRISMA_DAVERiskLimitUtilization";
         private final String accountMargin;
         private final String liquiGroupMargin;
         private final String liquiGroupSplitMargin;


### PR DESCRIPTION
Changes the default and README values to the correct queue names. Tests were unchanged and continue to use the old queue names.